### PR TITLE
replaced "snps,max-mtu" with "max-frame-size in socfpga_cyclone5.dts

### DIFF
--- a/arch/arm/boot/dts/socfpga_cyclone5.dts
+++ b/arch/arm/boot/dts/socfpga_cyclone5.dts
@@ -217,7 +217,7 @@
 	txc-skew-ps = <2600>;
 	rxdv-skew-ps = <0>;
 	rxc-skew-ps = <2000>;
-	snps,max-mtu = <3800>;
+	max-frame-size = <3800>;
 	status = "okay";
 };
 


### PR DESCRIPTION
The "snps,max-mtu" is not recognized by the stmmac driver, but "max-frame-size" is:
see file: stmmac_platform.c function: stmmac_probe_config_dt

of_property_read_u32(np, "max-frame-size", &plat->maxmtu);