### PR TITLE
Removed debugging code

### DIFF
--- a/arch/arm/mach-socfpga/socfpga.c
+++ b/arch/arm/mach-socfpga/socfpga.c
@@ -339,7 +339,6 @@ static int stmmac_plat_init(struct platform_device *pdev)
 
 	phymode = of_get_phy_mode(pdev->dev.of_node);
 
-    	phymode = PHY_INTERFACE_MODE_MII; //!!!
 	switch (phymode) {
 	case PHY_INTERFACE_MODE_RGMII:
 	case PHY_INTERFACE_MODE_RGMII_ID:


### PR DESCRIPTION
Removed what seems to be debugging code forgotten before committing. Phy mode should come from the device tree blob.